### PR TITLE
fix: App crashes on run

### DIFF
--- a/src/Forms/Composition/CompositionRoot.cs
+++ b/src/Forms/Composition/CompositionRoot.cs
@@ -33,7 +33,9 @@ namespace Showroom.Composition
 
             Locator
                 .CurrentMutable
-                .RegisterPlatform(registrar);
+                .RegisterPlatform(registrar)
+                .RegisterNavigationView(() => new NavigationView(RxApp.MainThreadScheduler, RxApp.TaskpoolScheduler, ViewLocator.Current))
+                .RegisterParameterViewStackService();
 
             Locator.CurrentMutable.UseSerilogFullLogger(Log.Logger);
 


### PR DESCRIPTION
What I figured out was that the NavigationView and the Navigation stack service creation was missing.
Adding those 2 lines (that I copied from Sextant setup page) fixed the issue.